### PR TITLE
[eco:matter] add matter support part 1

### DIFF
--- a/component/os/freertos/freertos_heap5_config.c
+++ b/component/os/freertos/freertos_heap5_config.c
@@ -185,13 +185,24 @@ void os_heap_init(void)
 #if defined(CONFIG_MATTER) && CONFIG_MATTER
 size_t xPortGetTotalHeapSize(void)
 {
-	if (hal_get_flash_port_cfg() != FLASH_PORTB) { // not a flash MCM package, so PSRAM on B port is possible
-		if (hal_lpcram_is_valid() == HAL_OK) {
+	if (hal_get_flash_port_cfg() != FLASH_PORTB) // not a flash MCM package, so PSRAM on B port is possible
+	{
+		if (hal_lpcram_is_valid() == HAL_OK)
+		{
+#ifdef CONFIG_PLATFORM_Z2PLUS
+			return configTOTAL_HEAP0_SIZE + configTOTAL_HEAP1_SIZE + configTOTAL_HEAP2_SIZE;
+#else
 			return configTOTAL_HEAP0_SIZE + configTOTAL_HEAP1_SIZE;
+#endif
 		}
-	} else {
-		return configTOTAL_HEAP0_SIZE;
 	}
+	else
+	{
+#ifdef CONFIG_PLATFORM_Z2PLUS
+		return configTOTAL_HEAP0_SIZE + configTOTAL_HEAP2_SIZE;
+#else
+		return configTOTAL_HEAP0_SIZE;
+#endif
 }
 /*-----------------------------------------------------------*/
 #endif

--- a/component/os/freertos/freertos_v10.0.1/Source/portable/MemMang/heap_5.c
+++ b/component/os/freertos/freertos_v10.0.1/Source/portable/MemMang/heap_5.c
@@ -535,14 +535,24 @@ size_t xPortGetMinimumEverFreeHeapSize( void )
 #if defined(CONFIG_MATTER) && CONFIG_MATTER
 size_t xPortGetTotalHeapSize( void )
 {
-	if(hal_get_flash_port_cfg() != FLASH_PORTB){ // not a flash MCM package, so PSRAM on B port is possible
-		if(hal_lpcram_is_valid() == HAL_OK){
+	if(hal_get_flash_port_cfg() != FLASH_PORTB) // not a flash MCM package, so PSRAM on B port is possible
+	{ 
+		if(hal_lpcram_is_valid() == HAL_OK)
+		{
+#ifdef CONFIG_PLATFORM_Z2PLUS
+			return configTOTAL_HEAP0_SIZE + configTOTAL_HEAP1_SIZE + configTOTAL_HEAP2_SIZE;
+#else
 			return configTOTAL_HEAP0_SIZE + configTOTAL_HEAP1_SIZE;
+#endif
 		}
 	}
 	else
 	{
+#ifdef CONFIG_PLATFORM_Z2PLUS
+		return configTOTAL_HEAP0_SIZE + configTOTAL_HEAP2_SIZE;
+#else
 		return configTOTAL_HEAP0_SIZE;
+#endif
 	}
 }
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
* fix inaccurate heap measurement when utilizing xPortGetTotalHeapSize().